### PR TITLE
feat(local): WiFi refresh stability; SaveLocal flow & serial extracti…

### DIFF
--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -12,5 +12,6 @@ public partial class AppShell : Shell
 		Routing.RegisterRoute("wifiscan", typeof(WifiScanPage));
 		Routing.RegisterRoute("localscan", typeof(LocalDevicesScanPage));
 		Routing.RegisterRoute("savedevice", typeof(SaveDevicePage));
+		Routing.RegisterRoute("savelocaldevice", typeof(SaveLocalDevicePage));
 	}
 }

--- a/Converters/BoolToColorConverter.cs
+++ b/Converters/BoolToColorConverter.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+
+namespace ReisingerIntelliApp_V4.Converters;
+
+public class BoolToColorConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool isTrue)
+        {
+            // Green for true, Red for false
+            return isTrue ? Colors.Green : Colors.Red;
+        }
+        return Colors.Gray;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Converters/IntToBoolConverter.cs
+++ b/Converters/IntToBoolConverter.cs
@@ -1,0 +1,23 @@
+using System.Globalization;
+
+namespace ReisingerIntelliApp_V4.Converters;
+
+public class IntToBoolConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        bool invert = parameter?.ToString() == "true";
+        
+        if (value is int count)
+        {
+            bool result = count > 0;
+            return invert ? !result : result;
+        }
+        return invert;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Converters/PercentageToProgressConverter.cs
+++ b/Converters/PercentageToProgressConverter.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+
+namespace ReisingerIntelliApp_V4.Converters;
+
+public class PercentageToProgressConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is double percentage)
+        {
+            return percentage / 100.0; // ProgressBar erwartet Werte zwischen 0.0 und 1.0
+        }
+        return 0.0;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is double progress)
+        {
+            return progress * 100.0;
+        }
+        return 0.0;
+    }
+}

--- a/Converters/StringToBoolConverter.cs
+++ b/Converters/StringToBoolConverter.cs
@@ -1,0 +1,23 @@
+using System.Globalization;
+
+namespace ReisingerIntelliApp_V4.Converters;
+
+public class StringToBoolConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        bool invert = parameter?.ToString() == "true";
+        
+        if (value is string str)
+        {
+            bool result = !string.IsNullOrWhiteSpace(str) && str != "Unknown";
+            return invert ? !result : result;
+        }
+        return invert;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/Converters/WifiConverters.cs
+++ b/Converters/WifiConverters.cs
@@ -27,17 +27,4 @@ namespace ReisingerIntelliApp_V4.Converters
             return value is bool b ? !b : false;
         }
     }
-
-    public class BoolToColorConverter : IValueConverter
-    {
-        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-        {
-            return value is bool isConnected && isConnected ? Colors.Green : Colors.Red;
-        }
-
-        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
-        {
-            throw new NotImplementedException();
-        }
-    }
 }

--- a/Helpers/ServiceCollectionExtensions.cs
+++ b/Helpers/ServiceCollectionExtensions.cs
@@ -29,11 +29,14 @@ public static class ServiceCollectionExtensions
         services.AddTransient<WifiScanPageViewModel>();
         services.AddTransient<LocalDevicesScanPageViewModel>();
         services.AddTransient<SaveDevicePageViewModel>();
+    services.AddTransient<SaveLocalDevicePageViewModel>();
 
         // Register Pages
         services.AddTransient<MainPage>();
         services.AddTransient<WifiScanPage>();
+        services.AddTransient<LocalDevicesScanPage>();
         services.AddTransient<SaveDevicePage>();
+    services.AddTransient<SaveLocalDevicePage>();
 
         return services;
     }

--- a/Models/IntellidriveApiModels.cs
+++ b/Models/IntellidriveApiModels.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ReisingerIntelliApp_V4.Models;
+
+// Generic envelope used by many Intellidrive endpoints
+public class IntellidriveApiEnvelope
+{
+    [JsonPropertyName("DeviceId")] public string DeviceId { get; set; } = string.Empty;
+    [JsonPropertyName("Success")] public bool Success { get; set; }
+    [JsonPropertyName("Message")] public string Message { get; set; } = string.Empty;
+    [JsonPropertyName("LatestFirmware")] public bool LatestFirmware { get; set; }
+    [JsonPropertyName("FirmwareVersion")] public string FirmwareVersion { get; set; } = string.Empty;
+    [JsonPropertyName("Content")] public JsonElement? Content { get; set; }
+}
+
+// Parameters API response
+public class IntellidriveParametersResponse
+{
+    [JsonPropertyName("Success")] public bool Success { get; set; }
+    [JsonPropertyName("Values")] public List<IntellidriveParameterValue>? Values { get; set; }
+}
+
+public class IntellidriveParameterValue
+{
+    [JsonPropertyName("Id")] public int Id { get; set; }
+    // Some values can be numbers/strings/bools; keep as JsonElement and consumers can convert
+    [JsonPropertyName("V")] public JsonElement V { get; set; }
+}

--- a/Models/LocalNetworkDeviceModel.cs
+++ b/Models/LocalNetworkDeviceModel.cs
@@ -1,0 +1,64 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ReisingerIntelliApp_V4.Models
+{
+    public partial class LocalNetworkDeviceModel : ObservableObject
+    {
+        [ObservableProperty]
+        private string id = string.Empty;
+
+        [ObservableProperty]
+        private string name = string.Empty;
+
+        [ObservableProperty]
+        private string ipAddress = string.Empty;
+
+        [ObservableProperty]
+        private string deviceId = string.Empty;
+
+        [ObservableProperty]
+        private string serialNumber = string.Empty;
+
+        [ObservableProperty]
+        private string firmwareVersion = string.Empty;
+
+        [ObservableProperty]
+        private string softwareVersion = string.Empty;
+
+        [ObservableProperty]
+        private string deviceType = "Intellidrive";
+
+        [ObservableProperty]
+        private bool latestFirmware;
+
+        [ObservableProperty]
+        private bool isAlreadySaved;
+
+        public bool IsNotAlreadySaved => !IsAlreadySaved;
+
+        [ObservableProperty]
+        private string customName = string.Empty;
+
+        [ObservableProperty]
+        private DateTime discoveredAt = DateTime.Now;
+
+        [ObservableProperty]
+        private DateTime lastSeen = DateTime.Now;
+
+        [ObservableProperty]
+        private DateTime responseTime = DateTime.Now;
+
+        [ObservableProperty]
+        private bool isOnline = true;
+
+        // Display properties for UI
+        public string DisplayName => !string.IsNullOrEmpty(CustomName) ? CustomName : 
+                                   !string.IsNullOrEmpty(Name) ? Name : 
+                                   !string.IsNullOrEmpty(SerialNumber) ? $"Intellidrive {SerialNumber}" :
+                                   $"Intellidrive {IpAddress}";
+        
+        public string DeviceInfo => $"{SerialNumber} • {IpAddress}";
+        public string StatusText => IsOnline ? "Online" : "Offline";
+        public string SavedStatusText => IsAlreadySaved ? "Gespeichert" : "Neu";
+    }
+}

--- a/Platforms/Android/AndroidManifest.xml
+++ b/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
+	<application 
+		android:allowBackup="true" 
+		android:icon="@mipmap/appicon" 
+		android:roundIcon="@mipmap/appicon_round" 
+		android:supportsRtl="true"
+		android:usesCleartextTraffic="true"
+		android:networkSecurityConfig="@xml/network_security_config" />
+
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />

--- a/Platforms/Android/Resources/xml/network_security_config.xml
+++ b/Platforms/Android/Resources/xml/network_security_config.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <base-config cleartextTrafficPermitted="true">
+    <trust-anchors>
+      <certificates src="system" />
+      <certificates src="user" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>

--- a/Resources/Styles/Styles.xaml
+++ b/Resources/Styles/Styles.xaml
@@ -2,7 +2,15 @@
 <?xaml-comp compile="true" ?>
 <ResourceDictionary 
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:converters="clr-namespace:ReisingerIntelliApp_V4.Converters">
+
+    <!-- Value Converters -->
+    <converters:SavedDeviceOpacityConverter x:Key="SavedDeviceOpacityConverter" />
+    <converters:PercentageToProgressConverter x:Key="PercentageToProgressConverter" />
+    <converters:IntToBoolConverter x:Key="IntToBoolConverter" />
+    <converters:StringToBoolConverter x:Key="StringToBoolConverter" />
+    <converters:InverseBoolConverter x:Key="InvertedBoolConverter" />
 
     <Style TargetType="ActivityIndicator">
         <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />

--- a/Services/AuthenticationService.cs
+++ b/Services/AuthenticationService.cs
@@ -31,17 +31,17 @@ public class AuthenticationService : IAuthenticationService
             // Use the intellidrive/beep endpoint for authentication test
             var endpoint = $"http://{ipAddress}/intellidrive/beep";
             
-            // Create authentication header using "User" scheme (matching V3)
-            var authValue = $"{username}:{password}";
-            _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("User", authValue);
+            // Build per-request message with auth header to avoid side effects on the shared client
+            var authValue = $"{username}:{password}"; // Device expects scheme 'User' with value 'username:password'
+            using var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("User", authValue);
+            request.Headers.Accept.Clear();
+            request.Headers.Accept.ParseAdd("application/json");
 
             System.Diagnostics.Debug.WriteLine($"🔄 Sending GET request to: {endpoint}");
             System.Diagnostics.Debug.WriteLine($"🔄 Authorization: User {username}:******");
 
-            var response = await _httpClient.GetAsync(endpoint);
-            
-            // Clear auth header after request
-            _httpClient.DefaultRequestHeaders.Authorization = null;
+            var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
             
             System.Diagnostics.Debug.WriteLine($"📶 Response status: {response.StatusCode}");
             

--- a/Services/DeviceService.cs
+++ b/Services/DeviceService.cs
@@ -1,5 +1,7 @@
 using ReisingerIntelliApp_V4.Models;
 using System.Text.Json;
+using System.Diagnostics;
+using System.Net;
 
 namespace ReisingerIntelliApp_V4.Services;
 
@@ -7,11 +9,13 @@ public interface IDeviceService
 {
     Task<List<DeviceModel>> ScanForWifiDevicesAsync();
     Task<List<DeviceModel>> ScanForLocalDevicesAsync(string startIp, string endIp);
+    Task<List<LocalNetworkDeviceModel>> ScanForLocalNetworkDevicesAsync(string startIp, string endIp);
     Task<DeviceModel?> GetDeviceDetailsAsync(string deviceId);
     Task<bool> ConnectToDeviceAsync(string deviceId);
     
     // New methods for saving/loading devices
     Task<List<DeviceModel>> GetSavedWifiDevicesAsync();
+    Task<List<DeviceModel>> GetSavedLocalDevicesAsync();
     Task<List<DeviceModel>> AddDeviceAndReturnUpdatedListAsync(DeviceModel device);
     Task SaveDeviceAsync(DeviceModel device);
     Task DeleteDeviceAsync(DeviceModel device);
@@ -23,6 +27,12 @@ public interface IDeviceService
 public class DeviceService : IDeviceService
 {
     private const string DevicesKey = "SavedDevices";
+    private readonly IntellidriveApiService _intellidriveApiService;
+
+    public DeviceService(IntellidriveApiService intellidriveApiService)
+    {
+        _intellidriveApiService = intellidriveApiService ?? throw new ArgumentNullException(nameof(intellidriveApiService));
+    }
 
     public async Task<List<DeviceModel>> ScanForWifiDevicesAsync()
     {
@@ -54,30 +64,148 @@ public class DeviceService : IDeviceService
 
     public async Task<List<DeviceModel>> ScanForLocalDevicesAsync(string startIp, string endIp)
     {
-        // Simulate scanning for local devices
-        await Task.Delay(3000); // Simulate network scanning delay
-        
-        return new List<DeviceModel>
+        try
         {
-            new() 
-            { 
-                DeviceId = "local_001", 
-                Name = "IT Door Right 1", 
-                IpAddress = "192.168.0.45", 
-                Type = AppDeviceType.LocalDevice, 
-                IsOnline = true, 
-                LastSeen = DateTime.Now 
-            },
-            new() 
-            { 
-                DeviceId = "local_002", 
-                Name = "Security Camera 01", 
-                IpAddress = "192.168.0.101", 
-                Type = AppDeviceType.SmartDevice, 
-                IsOnline = false, 
-                LastSeen = DateTime.Now.AddMinutes(-15) 
+            var foundDevices = new List<DeviceModel>();
+            var scannedDevices = await ScanForLocalNetworkDevicesAsync(startIp, endIp);
+            
+            foreach (var device in scannedDevices)
+            {
+                var deviceModel = new DeviceModel
+                {
+                    DeviceId = device.DeviceId ?? $"local_{DateTime.Now.Ticks}",
+                    Name = device.DisplayName,
+                    IpAddress = device.IpAddress,
+                    SerialNumber = device.SerialNumber,
+                    FirmwareVersion = device.FirmwareVersion,
+                    SoftwareVersion = device.SoftwareVersion,
+                    LatestFirmware = device.LatestFirmware,
+                    Type = AppDeviceType.LocalDevice,
+                    ConnectionType = ConnectionType.Local,
+                    IsOnline = device.IsOnline,
+                    LastUpdated = device.DiscoveredAt,
+                    Ip = device.IpAddress
+                };
+                
+                foundDevices.Add(deviceModel);
             }
-        };
+            
+            return foundDevices;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"❌ Error in ScanForLocalDevicesAsync: {ex.Message}");
+            return new List<DeviceModel>();
+        }
+    }
+
+    /// <summary>
+    /// Efficient parallel scanning of IP range for Intellidrive devices
+    /// Based on sophisticated implementation from V3 with improvements
+    /// </summary>
+    public async Task<List<LocalNetworkDeviceModel>> ScanForLocalNetworkDevicesAsync(string startIp, string endIp)
+    {
+        var foundDevices = new List<LocalNetworkDeviceModel>();
+        
+        try
+        {
+            Debug.WriteLine($"🔍 Starting local network scan from {startIp} to {endIp}");
+            
+            // Get saved device serial numbers for comparison
+            var savedDevices = await GetSavedLocalDevicesAsync();
+            var savedSerialNumbers = savedDevices.Select(d => d.SerialNumber).ToHashSet();
+            
+            // Parse IP range
+            var startBytes = IPAddress.Parse(startIp).GetAddressBytes();
+            var endBytes = IPAddress.Parse(endIp).GetAddressBytes();
+            uint start = BitConverter.ToUInt32(startBytes.Reverse().ToArray(), 0);
+            uint end = BitConverter.ToUInt32(endBytes.Reverse().ToArray(), 0);
+            
+            // Generate list of IP addresses to scan
+            var ipsToScan = Enumerable
+                .Range(0, (int)(end - start + 1))
+                .Select(i => {
+                    uint ip = start + (uint)i;
+                    byte[] bytes = BitConverter.GetBytes(ip).Reverse().ToArray();
+                    return new IPAddress(bytes).ToString();
+                })
+                .ToList();
+            
+            Debug.WriteLine($"📡 Scanning {ipsToScan.Count} IP addresses with parallel processing");
+            
+            // Use SemaphoreSlim for controlled parallelism (max 20 concurrent connections)
+            using var semaphore = new SemaphoreSlim(20, 20);
+            var scanTasks = ipsToScan.Select(async ip => {
+                await semaphore.WaitAsync();
+                try
+                {
+                    return await ScanSingleDeviceAsync(ip, savedSerialNumbers);
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+            });
+            
+            var results = await Task.WhenAll(scanTasks);
+            foundDevices = results.Where(d => d != null).Cast<LocalNetworkDeviceModel>().ToList();
+            
+            Debug.WriteLine($"✅ Network scan completed. Found {foundDevices.Count} devices");
+            
+            return foundDevices;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"❌ Error during network scan: {ex.Message}");
+            return foundDevices;
+        }
+    }
+    
+    private async Task<LocalNetworkDeviceModel?> ScanSingleDeviceAsync(string ipAddress, HashSet<string> savedSerialNumbers)
+    {
+        try
+        {
+            var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            
+            // Try to get version info from the device
+            var versionResponse = await _intellidriveApiService.GetVersionAsync(ipAddress, timeoutSeconds: 3);
+            
+            stopwatch.Stop();
+            
+            if (versionResponse != null && !string.IsNullOrEmpty(versionResponse.Message))
+            {
+                var device = new LocalNetworkDeviceModel
+                {
+                    IpAddress = ipAddress,
+                    DeviceId = versionResponse.DeviceId ?? $"local_{DateTime.Now.Ticks}",
+                    SerialNumber = versionResponse.DeviceId ?? "Unknown",
+                    FirmwareVersion = versionResponse.FirmwareVersion ?? "Unknown",
+                    SoftwareVersion = versionResponse.Message ?? "Unknown", 
+                    LatestFirmware = versionResponse.LatestFirmware,
+                    IsAlreadySaved = savedSerialNumbers.Contains(versionResponse.DeviceId ?? ""),
+                    DiscoveredAt = DateTime.Now,
+                    IsOnline = true,
+                    ResponseTime = DateTime.Now // Fixed: Use DateTime instead of TimeSpan
+                };
+                
+                Debug.WriteLine($"✅ Found device at {ipAddress}: {device.SerialNumber} (Response: {stopwatch.ElapsedMilliseconds}ms)");
+                return device;
+            }
+        }
+        catch (HttpRequestException)
+        {
+            // Device not reachable - this is expected for most IPs
+        }
+        catch (TaskCanceledException)
+        {
+            // Timeout - also expected
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"⚠️ Error scanning {ipAddress}: {ex.Message}");
+        }
+        
+        return null;
     }
 
     public async Task<DeviceModel?> GetDeviceDetailsAsync(string deviceId)
@@ -171,6 +299,38 @@ public class DeviceService : IDeviceService
         {
             System.Diagnostics.Debug.WriteLine($"❌ Error loading device list: {ex.Message}");
             return (false, true, new List<DeviceModel>());
+        }
+    }
+
+    public async Task<List<DeviceModel>> GetSavedLocalDevicesAsync()
+    {
+        try
+        {
+            var (isSuccessful, isEmpty, devices) = await LoadDeviceListAsync();
+            
+            if (!isSuccessful)
+            {
+                Debug.WriteLine("❌ Failed to load device list for local devices");
+                return new List<DeviceModel>();
+            }
+            
+            if (isEmpty)
+            {
+                Debug.WriteLine("📭 No devices found in storage");
+                return new List<DeviceModel>();
+            }
+            
+            // Filter for local devices only
+            var localDevices = devices.Where(d => d.ConnectionType == ConnectionType.Local).ToList();
+            
+            Debug.WriteLine($"🏠 Found {localDevices.Count} saved local devices");
+            
+            return localDevices;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"❌ Error getting saved local devices: {ex.Message}");
+            return new List<DeviceModel>();
         }
     }
 

--- a/ViewModels/LocalDevicesScanPageViewModel.cs
+++ b/ViewModels/LocalDevicesScanPageViewModel.cs
@@ -1,66 +1,575 @@
-using System.Windows.Input;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Net;
+using System.Text.Json;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ReisingerIntelliApp_V4.Models;
+using ReisingerIntelliApp_V4.Services;
 
 namespace ReisingerIntelliApp_V4.ViewModels;
 
-public class LocalDevicesScanPageViewModel : BaseViewModel
+public partial class LocalDevicesScanPageViewModel : ObservableObject
 {
-    public LocalDevicesScanPageViewModel()
+    private readonly IDeviceService _deviceService;
+    private readonly IntellidriveApiService _apiService;
+    private CancellationTokenSource? _cancellationTokenSource;
+    // Slightly higher timeout for on-device LAN scanning due to WiFi latency & Android scheduler
+    private static readonly HttpClient _httpClient = new() { Timeout = TimeSpan.FromMilliseconds(2500) };
+    private const int MaxConcurrency = 20; // Optimiert für bessere Performance
+
+    public LocalDevicesScanPageViewModel(IDeviceService deviceService, IntellidriveApiService apiService)
     {
-        Title = "Local Devices Scan";
-        HomeCommand = new Command(OnHomeTapped);
-        RefreshCommand = new Command(OnRefreshTapped);
-        SettingsCommand = new Command(OnSettingsTapped);
-        BackCommand = new Command(OnBackButtonClicked);
-        ScanCommand = new Command(OnScanButtonClicked);
+        _deviceService = deviceService ?? throw new ArgumentNullException(nameof(deviceService));
+        _apiService = apiService ?? throw new ArgumentNullException(nameof(apiService));
+        
+        LocalDevices = new ObservableCollection<LocalNetworkDeviceModel>();
+        
+        // Set default IP range for most common local networks
+        StartIp = "192.168.1.1";
+        EndIp = "192.168.1.254";
     }
 
-    public ICommand HomeCommand { get; }
-    public ICommand RefreshCommand { get; }
-    public ICommand SettingsCommand { get; }
-    public ICommand BackCommand { get; }
-    public ICommand ScanCommand { get; }
+    [ObservableProperty]
+    private ObservableCollection<LocalNetworkDeviceModel> localDevices;
 
-    private async void OnHomeTapped()
-    {
-        await Shell.Current.GoToAsync("..");
-    }
+    [ObservableProperty]
+    private string startIp = "192.168.1.1";
 
-    private async void OnRefreshTapped()
+    [ObservableProperty]
+    private string endIp = "192.168.1.254";
+
+    [ObservableProperty]
+    private bool isScanning;
+
+    [ObservableProperty]
+    private string scanStatusMessage = "Bereit für lokalen Netzwerk-Scan";
+
+    [ObservableProperty]
+    private int scannedCount = 0;
+
+    [ObservableProperty]
+    private int totalCount = 0;
+
+    [ObservableProperty]
+    private double progressPercentage = 0;
+
+    [ObservableProperty]
+    private int foundDevicesCount = 0;
+
+    [ObservableProperty]
+    private LocalNetworkDeviceModel? selectedDevice;
+
+    [ObservableProperty]
+    private string validationMessage = string.Empty;
+
+    [ObservableProperty]
+    private bool hasValidationError = false;
+
+    [RelayCommand]
+    private async Task StartLocalScanAsync()
     {
-        IsBusy = true;
+        if (IsScanning) return;
+
         try
         {
-            if (Application.Current?.MainPage != null)
-                await Application.Current.MainPage.DisplayAlert("Refresh", "Refreshing local devices scan...", "OK");
+            // Cancel any existing scan
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource = new CancellationTokenSource();
+
+            IsScanning = true;
+            ScannedCount = 0;
+            FoundDevicesCount = 0;
+            ProgressPercentage = 0;
+            LocalDevices.Clear();
+            ScanStatusMessage = "🔍 Starte lokalen Netzwerk-Scan...";
+
+            Debug.WriteLine($"🏠 Starting local network scan from {StartIp} to {EndIp}");
+
+            // Validate IP addresses
+            if (!IsValidIpAddress(StartIp) || !IsValidIpAddress(EndIp))
+            {
+                ScanStatusMessage = "❌ Ungültige IP-Adressen eingegeben. Bitte prüfen Sie das Format (z.B. 192.168.1.1)";
+                ValidationMessage = "Ungültige IP-Adressen eingegeben";
+                HasValidationError = true;
+                return;
+            }
+
+            // Validate IP range
+            if (!IsValidIpRange(StartIp, EndIp))
+            {
+                ScanStatusMessage = "❌ Start-IP muss kleiner oder gleich End-IP sein";
+                ValidationMessage = "Start-IP muss kleiner oder gleich End-IP sein";
+                HasValidationError = true;
+                return;
+            }
+
+            // Clear validation errors
+            ValidationMessage = string.Empty;
+            HasValidationError = false;
+
+            // Generate IP range
+            var ipList = GenerateIpRange(StartIp, EndIp);
+            if (ipList.Count == 0)
+            {
+                ScanStatusMessage = "❌ Fehler beim Generieren des IP-Bereichs";
+                return;
+            }
+
+            if (ipList.Count > 1000)
+            {
+                ScanStatusMessage = "⚠️ IP-Bereich zu groß (max. 1000 IPs). Bitte verkleinern Sie den Bereich.";
+                return;
+            }
+
+            TotalCount = ipList.Count;
+            ScanStatusMessage = $"🔍 Scanne {TotalCount} IP-Adressen...";
+
+            Debug.WriteLine($"🚀 Starting scan of {TotalCount} IPs");
+
+            // Start parallel scan with live updates
+            await ScanIpRangeWithLiveUpdatesAsync(ipList, _cancellationTokenSource.Token);
+
+            if (!_cancellationTokenSource.Token.IsCancellationRequested)
+            {
+                ScanStatusMessage = LocalDevices.Count > 0 
+                    ? $"✅ Scan abgeschlossen: {LocalDevices.Count} Intellidrive-Geräte gefunden"
+                    : "⚠️ Keine Intellidrive-Geräte im angegebenen Bereich gefunden";
+            }
+
+            Debug.WriteLine($"🎯 Local scan completed: {LocalDevices.Count} devices found");
+        }
+        catch (OperationCanceledException)
+        {
+            ScanStatusMessage = "⏹️ Scan abgebrochen";
+            Debug.WriteLine("🛑 Local scan was cancelled");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"❌ Error during local scan: {ex.Message}");
+            ScanStatusMessage = $"❌ Fehler beim Scannen: {ex.Message}";
         }
         finally
         {
-            IsBusy = false;
+            IsScanning = false;
+            _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = null;
         }
     }
 
-    private async void OnSettingsTapped()
+    private async Task ScanIpRangeWithLiveUpdatesAsync(List<string> ipAddresses, CancellationToken cancellationToken)
     {
-        if (Application.Current?.MainPage != null)
-            await Application.Current.MainPage.DisplayAlert("Settings", "Opening settings...", "OK");
+        var semaphore = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
+        var scannedCounter = 0;
+
+        var tasks = ipAddresses.Select(async ip =>
+        {
+            await semaphore.WaitAsync(cancellationToken);
+            try
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                // Update current scanning IP immediately
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    ScanStatusMessage = $"🔍 Scanne gerade: {ip}";
+                });
+
+                var device = await TestSingleIpForIntellidriveAsync(ip, cancellationToken);
+                if (device != null)
+                {
+                    // UI-Update auf Main Thread - Sofortiges Hinzufügen zur Liste
+                    await MainThread.InvokeOnMainThreadAsync(() =>
+                    {
+                        LocalDevices.Add(device);
+                        FoundDevicesCount = LocalDevices.Count;
+                        ScanStatusMessage = $"✅ Gefunden: {device.DisplayName} ({device.IpAddress}) - Scan läuft weiter...";
+                    });
+
+                    Debug.WriteLine($"✅ Found Intellidrive device: {device.DisplayName} at {device.IpAddress}");
+                }
+
+                // Progress Update
+                var completed = Interlocked.Increment(ref scannedCounter);
+                var progress = (double)completed / TotalCount * 100;
+                
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    ScannedCount = completed;
+                    ProgressPercentage = progress;
+                });
+            }
+            catch (OperationCanceledException)
+            {
+                // Cancellation is expected, just return
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        });
+
+        await Task.WhenAll(tasks);
     }
 
-    private async void OnBackButtonClicked()
+    private async Task<LocalNetworkDeviceModel?> TestSingleIpForIntellidriveAsync(string ipAddress, CancellationToken cancellationToken)
     {
-        await Shell.Current.GoToAsync("..");
-    }
-
-    private async void OnScanButtonClicked()
-    {
-        IsBusy = true;
         try
         {
-            if (Application.Current?.MainPage != null)
-                await Application.Current.MainPage.DisplayAlert("Scan", "Starting local devices scan...", "OK");
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var stopwatch = Stopwatch.StartNew();
+            
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"http://{ipAddress}/intellidrive/version");
+            var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+            
+            stopwatch.Stop();
+            
+            if (response.IsSuccessStatusCode)
+            {
+                var content = await response.Content.ReadAsStringAsync(cancellationToken);
+                Debug.WriteLine($"🔍 Response from {ipAddress}: {content}");
+                
+                // Prüfe ob es eine gültige Intellidrive JSON-Response ist
+                if (IsValidIntellidriveResponse(content))
+                {
+                    return await CreateDeviceFromResponseAsync(ipAddress, content, stopwatch.ElapsedMilliseconds, cancellationToken);
+                }
+            }
         }
-        finally
+        catch (OperationCanceledException)
         {
-            IsBusy = false;
+            throw; // Re-throw cancellation
+        }
+        catch (HttpRequestException httpEx)
+        {
+            Debug.WriteLine($"⚠️ IP {ipAddress} HTTP error: {httpEx.Message} ({httpEx.StatusCode})");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"⚠️ IP {ipAddress} test failed: {ex.GetType().Name}: {ex.Message}");
+        }
+
+        return null;
+    }
+
+    private static bool IsValidIntellidriveResponse(string jsonContent)
+    {
+        if (string.IsNullOrWhiteSpace(jsonContent))
+            return false;
+
+        try
+        {
+            // Prüfe auf typische Intellidrive JSON-Inhalte
+            return jsonContent.Contains("\"Success\":true") || 
+                   jsonContent.Contains("\"success\":true") ||
+                   jsonContent.Contains("\"DeviceId\"") || 
+                   jsonContent.Contains("\"deviceId\"") ||
+                   jsonContent.Contains("\"version\"") ||
+                   jsonContent.Contains("\"Version\"") ||
+                   jsonContent.Contains("intellidrive") ||
+                   jsonContent.Contains("Intellidrive");
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private async Task<LocalNetworkDeviceModel> CreateDeviceFromResponseAsync(string ipAddress, string jsonResponse, long responseTimeMs, CancellationToken cancellationToken)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // Versuche zusätzliche Geräteinformationen zu holen
+            string deviceId = ExtractValueFromJson(jsonResponse, "DeviceId") ?? 
+                            ExtractValueFromJson(jsonResponse, "deviceId") ?? 
+                            Guid.NewGuid().ToString();
+            
+            string firmwareVersion = ExtractValueFromJson(jsonResponse, "Version") ?? 
+                                   ExtractValueFromJson(jsonResponse, "version") ?? 
+                                   ExtractValueFromJson(jsonResponse, "firmware") ??
+                                   "Unknown";
+
+            // Versuche Serial Number aus der Version-Response (Content.DEVICE_SERIALNO) zu lesen,
+            // und falle nur bei Bedarf auf den separaten API-Call zurück
+            string serialNumber = ExtractValueFromJson(jsonResponse, "DEVICE_SERIALNO") ?? "Unknown";
+            if (string.IsNullOrWhiteSpace(serialNumber) || serialNumber == "Unknown")
+            {
+                try
+                {
+                    using var serialRequest = new HttpRequestMessage(HttpMethod.Get, $"http://{ipAddress}/intellidrive/device_id");
+                    var serialResponse = await _httpClient.SendAsync(serialRequest, cancellationToken);
+                    if (serialResponse.IsSuccessStatusCode)
+                    {
+                        var serialContent = await serialResponse.Content.ReadAsStringAsync(cancellationToken);
+                        serialNumber = ExtractValueFromJson(serialContent, "DEVICE_ID") ?? 
+                                     ExtractValueFromJson(serialContent, "device_id") ?? 
+                                     ExtractValueFromJson(serialContent, "SerialNumber") ?? 
+                                     "Unknown";
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw; // Re-throw cancellation
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"⚠️ Could not get serial for {ipAddress}: {ex.Message}");
+                }
+            }
+
+            return new LocalNetworkDeviceModel
+            {
+                Id = deviceId,
+                DeviceId = deviceId,
+                Name = $"Intellidrive {serialNumber}",
+                IpAddress = ipAddress,
+                LastSeen = DateTime.Now,
+                IsOnline = true,
+                DeviceType = "Intellidrive",
+                FirmwareVersion = firmwareVersion,
+                SerialNumber = serialNumber,
+                ResponseTime = DateTime.Now,
+                DiscoveredAt = DateTime.Now
+            };
+        }
+        catch (OperationCanceledException)
+        {
+            throw; // Re-throw cancellation
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"⚠️ Error creating device model for {ipAddress}: {ex.Message}");
+            
+            return new LocalNetworkDeviceModel
+            {
+                Id = Guid.NewGuid().ToString(),
+                DeviceId = Guid.NewGuid().ToString(),
+                Name = $"Intellidrive {ipAddress}",
+                IpAddress = ipAddress,
+                LastSeen = DateTime.Now,
+                IsOnline = true,
+                DeviceType = "Intellidrive",
+                FirmwareVersion = "Unknown",
+                SerialNumber = "Unknown",
+                ResponseTime = DateTime.Now,
+                DiscoveredAt = DateTime.Now
+            };
+        }
+    }
+
+    private static string? ExtractValueFromJson(string json, string key)
+    {
+        try
+        {
+            var pattern = $"\"{key}\":\"([^\"]+)\"";
+            var match = System.Text.RegularExpressions.Regex.Match(json, pattern);
+            return match.Success ? match.Groups[1].Value : null;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static List<string> GenerateIpRange(string startIp, string endIp)
+    {
+        var ips = new List<string>();
+        try
+        {
+            var start = IPAddress.Parse(startIp).GetAddressBytes();
+            var end = IPAddress.Parse(endIp).GetAddressBytes();
+
+            uint startInt = BitConverter.ToUInt32(start.Reverse().ToArray(), 0);
+            uint endInt = BitConverter.ToUInt32(end.Reverse().ToArray(), 0);
+
+            for (uint i = startInt; i <= endInt; i++)
+            {
+                var bytes = BitConverter.GetBytes(i).Reverse().ToArray();
+                ips.Add(new IPAddress(bytes).ToString());
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"❌ Error generating IP range: {ex.Message}");
+        }
+
+        return ips;
+    }
+
+    [RelayCommand]
+    private void StopScan()
+    {
+        if (IsScanning && _cancellationTokenSource != null)
+        {
+            _cancellationTokenSource.Cancel();
+            ScanStatusMessage = "⏹️ Scan wird abgebrochen...";
+            Debug.WriteLine("🛑 Local scan cancellation requested by user");
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveSelectedDeviceAsync()
+    {
+        if (SelectedDevice == null)
+        {
+            ScanStatusMessage = "⚠️ Kein Gerät zum Speichern ausgewählt";
+            return;
+        }
+
+        try
+        {
+            // Navigiere zur Save Device Page mit dem ausgewählten Gerät
+            var parameters = new Dictionary<string, object>
+            {
+                ["Device"] = SelectedDevice
+            };
+            
+            await Shell.Current.GoToAsync("//SaveDevicePage", parameters);
+            Debug.WriteLine($"🔗 Navigating to save device: {SelectedDevice.DisplayName}");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"❌ Error navigating to save device: {ex.Message}");
+            ScanStatusMessage = $"❌ Fehler beim Öffnen der Speichern-Seite: {ex.Message}";
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveDeviceAsync(LocalNetworkDeviceModel device)
+    {
+        try
+        {
+            Debug.WriteLine($"🔗 Navigating to save device: {device.DisplayName}");
+
+            // Create device model for saving
+            var deviceModel = new DeviceModel
+            {
+                DeviceId = device.DeviceId,
+                Name = device.DisplayName,
+                IpAddress = device.IpAddress,
+                SerialNumber = device.SerialNumber,
+                FirmwareVersion = device.FirmwareVersion,
+                Type = AppDeviceType.LocalDevice,
+                ConnectionType = ConnectionType.Local,
+                LastSeen = device.LastSeen,
+                IsOnline = device.IsOnline,
+                Ip = device.IpAddress
+            };
+
+            // Save device via service
+            await _deviceService.SaveDeviceAsync(deviceModel);
+            
+            // Mark as saved in UI
+            device.IsAlreadySaved = true;
+            
+            ScanStatusMessage = $"✅ Gerät '{device.DisplayName}' erfolgreich gespeichert";
+            
+            Debug.WriteLine($"✅ Device saved successfully: {device.DisplayName}");
+            
+            // Trigger a refresh of the MainPage Local Devices dropdown if it's open
+            MessagingCenter.Send(this, "LocalDeviceAdded");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"❌ Error saving device: {ex.Message}");
+            ScanStatusMessage = $"❌ Fehler beim Speichern: {ex.Message}";
+        }
+    }
+
+    // Mirrors WifiScanViewModel.AddDevice: navigate to save page with prefilled local device data
+    [RelayCommand]
+    private async Task AddDeviceAsync(LocalNetworkDeviceModel device)
+    {
+        try
+        {
+            if (device == null)
+            {
+                ScanStatusMessage = "⚠️ Kein Gerät ausgewählt";
+                return;
+            }
+
+            // Serialize minimal local device data for navigation
+            var payload = new
+            {
+                ip = device.IpAddress,
+                name = device.DisplayName,
+                serial = device.SerialNumber,
+                firmware = device.FirmwareVersion,
+                deviceId = device.DeviceId
+            };
+
+            var json = JsonSerializer.Serialize(payload);
+            var encoded = Uri.EscapeDataString(json);
+
+            await Shell.Current.GoToAsync($"savelocaldevice?deviceData={encoded}");
+            Debug.WriteLine($"🔗 Navigating to SaveLocalDevicePage for {device.DisplayName} ({device.IpAddress})");
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"❌ Error navigating to SaveLocalDevicePage: {ex.Message}");
+            ScanStatusMessage = $"❌ Navigation fehlgeschlagen: {ex.Message}";
+        }
+    }
+
+    [RelayCommand]
+    private void SelectDevice(LocalNetworkDeviceModel device)
+    {
+        SelectedDevice = device;
+        Debug.WriteLine($"📱 Selected device: {device.DisplayName} at {device.IpAddress}");
+    }
+
+    [RelayCommand]
+    private void SetCommonIpRange(string range)
+    {
+        switch (range.ToLower())
+        {
+            case "192.168.1.x":
+                StartIp = "192.168.1.1";
+                EndIp = "192.168.1.254";
+                break;
+            case "192.168.0.x":
+                StartIp = "192.168.0.1";
+                EndIp = "192.168.0.254";
+                break;
+            case "10.0.0.x":
+                StartIp = "10.0.0.1";
+                EndIp = "10.0.0.254";
+                break;
+            case "172.16.0.x":
+                StartIp = "172.16.0.1";
+                EndIp = "172.16.0.254";
+                break;
+            default:
+                Debug.WriteLine($"⚠️ Unknown IP range preset: {range}");
+                break;
+        }
+        
+        ScanStatusMessage = $"📋 IP-Bereich gesetzt: {StartIp} - {EndIp}";
+    }
+
+    private static bool IsValidIpAddress(string ipAddress)
+    {
+        return System.Net.IPAddress.TryParse(ipAddress, out _);
+    }
+
+    private static bool IsValidIpRange(string startIp, string endIp)
+    {
+        try
+        {
+            var start = IPAddress.Parse(startIp).GetAddressBytes();
+            var end = IPAddress.Parse(endIp).GetAddressBytes();
+
+            uint startInt = BitConverter.ToUInt32(start.Reverse().ToArray(), 0);
+            uint endInt = BitConverter.ToUInt32(end.Reverse().ToArray(), 0);
+
+            return startInt <= endInt;
+        }
+        catch
+        {
+            return false;
         }
     }
 }

--- a/ViewModels/SaveLocalDevicePageViewModel.cs
+++ b/ViewModels/SaveLocalDevicePageViewModel.cs
@@ -1,0 +1,293 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using ReisingerIntelliApp_V4.Models;
+using ReisingerIntelliApp_V4.Services;
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace ReisingerIntelliApp_V4.ViewModels;
+
+[QueryProperty(nameof(DeviceData), "deviceData")]
+public partial class SaveLocalDevicePageViewModel : ObservableObject, IDisposable
+{
+    private readonly IDeviceService _deviceService;
+    private readonly IAuthenticationService _authService;
+    private readonly IntellidriveApiService _apiService;
+    private Timer? _onlineStatusTimer;
+    private readonly object _timerLock = new object();
+
+    public SaveLocalDevicePageViewModel(IDeviceService deviceService, IAuthenticationService authService, IntellidriveApiService apiService)
+    {
+        _deviceService = deviceService;
+        _authService = authService;
+        _apiService = apiService;
+    TestButtonText = "Verbindung testen";
+    CanTestConnection = true;
+    }
+
+    [ObservableProperty]
+    private string deviceData = string.Empty;
+
+    [ObservableProperty]
+    private string deviceName = string.Empty;
+
+    [ObservableProperty]
+    private string ipAddress = string.Empty;
+
+    [ObservableProperty]
+    private string firmwareVersion = string.Empty;
+
+    [ObservableProperty]
+    private string serialNumber = string.Empty;
+
+    [ObservableProperty]
+    private string statusMessage = string.Empty;
+
+    [ObservableProperty]
+    private bool showStatusMessage;
+
+    [ObservableProperty]
+    private bool isReachable;
+
+    [ObservableProperty]
+    private bool isOnline;
+
+    [ObservableProperty]
+    private bool canSaveDevice;
+
+    // Added to mirror SaveDevicePage patterns
+    [ObservableProperty]
+    private string username = string.Empty;
+
+    [ObservableProperty]
+    private string password = string.Empty;
+
+    [ObservableProperty]
+    private Color statusColor = Colors.Black;
+
+    [ObservableProperty]
+    private bool isTestingConnection = false;
+
+    [ObservableProperty]
+    private string testButtonText = string.Empty;
+
+    [ObservableProperty]
+    private bool canTestConnection = false;
+
+    partial void OnDeviceDataChanged(string value)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(value)) return;
+            var json = Uri.UnescapeDataString(value);
+            var payload = JsonSerializer.Deserialize<Payload>(json);
+            if (payload != null)
+            {
+                DeviceName = string.IsNullOrWhiteSpace(payload.name) ? "Local Device" : payload.name;
+                IpAddress = payload.ip ?? string.Empty;
+                FirmwareVersion = payload.firmware ?? string.Empty;
+                SerialNumber = payload.serial ?? string.Empty;
+                CanSaveDevice = !string.IsNullOrEmpty(IpAddress) && !string.IsNullOrWhiteSpace(DeviceName);
+                UpdateCanTestConnection();
+                // Start online status monitoring when IP is known
+                if (!string.IsNullOrWhiteSpace(IpAddress))
+                {
+                    StartOnlineStatusMonitoring();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"❌ Error parsing deviceData: {ex.Message}");
+        }
+    }
+
+    [RelayCommand]
+    private async Task TestConnectionAsync()
+    {
+        // Mirror WiFi test: require credentials, authenticate against device at IpAddress
+        if (IsTestingConnection) return;
+
+        if (string.IsNullOrWhiteSpace(IpAddress))
+        {
+            UpdateStatusMessage("❌ Keine IP-Adresse vorhanden", Colors.Red, true);
+            return;
+        }
+
+        if (string.IsNullOrEmpty(Username) || string.IsNullOrEmpty(Password))
+        {
+            UpdateStatusMessage("❌ Bitte geben Sie Benutzername und Passwort ein", Colors.Red, true);
+            return;
+        }
+
+        IsTestingConnection = true;
+        TestButtonText = "Teste Verbindung...";
+    UpdateStatusMessage("Verbindung wird getestet...", Colors.Orange, true);
+
+        try
+        {
+            // Call the authenticated beep endpoint directly; some devices don't respond to /version quickly or without auth
+            var authenticated = await _authService.TestUserAuthAsync(IpAddress, Username, Password);
+            if (authenticated)
+            {
+                IsReachable = true;
+                IsOnline = true;
+                UpdateStatusMessage("✅ Gerät erfolgreich authentifiziert und erreichbar", Colors.Green, true);
+            }
+            else
+            {
+                IsReachable = false;
+                IsOnline = false;
+                UpdateStatusMessage("❌ Authentifizierung fehlgeschlagen - prüfen Sie Benutzername/Passwort", Colors.Red, true);
+            }
+        }
+        catch (Exception ex)
+        {
+            UpdateStatusMessage($"❌ Fehler beim Test: {ex.Message}", Colors.Red, true);
+        }
+        finally
+        {
+            IsTestingConnection = false;
+            TestButtonText = "Verbindung testen";
+            UpdateCanTestConnection();
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveDeviceAsync()
+    {
+        try
+        {
+            var model = new DeviceModel
+            {
+                DeviceId = Guid.NewGuid().ToString(),
+                Name = DeviceName,
+                IpAddress = IpAddress,
+                FirmwareVersion = FirmwareVersion,
+                SerialNumber = SerialNumber,
+                Type = AppDeviceType.LocalDevice,
+                ConnectionType = ConnectionType.Local,
+                LastSeen = DateTime.Now,
+                IsOnline = true,
+                Ip = IpAddress,
+                Username = Username,
+                Password = Password
+            };
+
+            await _deviceService.SaveDeviceAsync(model);
+            // Notify listeners that a new local device was added
+            MessagingCenter.Send(this, "LocalDeviceAdded");
+            await Shell.Current.GoToAsync("../..");
+        }
+        catch (Exception ex)
+        {
+            UpdateStatusMessage($"❌ Speichern fehlgeschlagen: {ex.Message}", Colors.Red, true);
+        }
+    }
+
+    [RelayCommand]
+    private async Task CancelAsync()
+    {
+        await Shell.Current.GoToAsync("..");
+    }
+
+    [RelayCommand]
+    private async Task BackAsync()
+    {
+        await Shell.Current.GoToAsync("..");
+    }
+
+    private record Payload(string ip, string name, string serial, string firmware, string deviceId);
+
+    private void UpdateStatusMessage(string message, Color color, bool show)
+    {
+        StatusMessage = message;
+        StatusColor = color;
+        ShowStatusMessage = show;
+    }
+
+    partial void OnUsernameChanged(string value) => UpdateCanTestConnection();
+    partial void OnPasswordChanged(string value) => UpdateCanTestConnection();
+    partial void OnDeviceNameChanged(string value) => CanSaveDevice = !string.IsNullOrWhiteSpace(value) && !string.IsNullOrWhiteSpace(IpAddress);
+
+    private void UpdateCanTestConnection()
+    {
+        // Enable only when we have the required inputs and we're not already testing
+        CanTestConnection = !IsTestingConnection
+                             && !string.IsNullOrWhiteSpace(IpAddress)
+                             && !string.IsNullOrWhiteSpace(Username)
+                             && !string.IsNullOrWhiteSpace(Password);
+    }
+
+    #region Online status monitoring (every 3s via /intellidrive/version)
+
+    public void StartOnlineStatusMonitoring()
+    {
+        lock (_timerLock)
+        {
+            _onlineStatusTimer?.Dispose();
+            // Poll every 3 seconds as requested
+            _onlineStatusTimer = new Timer(async _ => await CheckOnlineStatusAsync(), null, TimeSpan.Zero, TimeSpan.FromSeconds(3));
+            Debug.WriteLine("🔄 Local device online status monitoring started (3s interval)");
+        }
+    }
+
+    public void StopOnlineStatusMonitoring()
+    {
+        lock (_timerLock)
+        {
+            _onlineStatusTimer?.Dispose();
+            _onlineStatusTimer = null;
+            Debug.WriteLine("⏹️ Local device online status monitoring stopped");
+        }
+    }
+
+    private async Task CheckOnlineStatusAsync()
+    {
+        var ip = IpAddress;
+        if (string.IsNullOrWhiteSpace(ip)) return;
+
+        try
+        {
+            var (success, _, _) = await _apiService.TestIntellidriveConnectionAsync(ip);
+            if (IsOnline != success)
+            {
+                MainThread.BeginInvokeOnMainThread(() =>
+                {
+                    IsOnline = success;
+                    // Optional: surface a lightweight status text when testing manually is not in progress
+                    if (!IsTestingConnection)
+                    {
+                        StatusMessage = success ? "✅ Gerät online" : "❌ Gerät offline";
+                        StatusColor = success ? Colors.Green : Colors.Red;
+                        ShowStatusMessage = true;
+                    }
+                });
+            }
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"❌ Error checking local device online status: {ex.Message}");
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                if (IsOnline)
+                {
+                    IsOnline = false;
+                    if (!IsTestingConnection)
+                    {
+                        StatusMessage = "❌ Gerät offline";
+                        StatusColor = Colors.Red;
+                        ShowStatusMessage = true;
+                    }
+                }
+            });
+        }
+    }
+
+    public void Dispose()
+    {
+        StopOnlineStatusMonitoring();
+    }
+
+    #endregion
+}

--- a/Views/LocalDevicesScanPage.xaml
+++ b/Views/LocalDevicesScanPage.xaml
@@ -1,128 +1,307 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             xmlns:components="clr-namespace:ReisingerIntelliApp_V4.Components"
-             xmlns:viewmodels="clr-namespace:ReisingerIntelliApp_V4.ViewModels"
-             x:Class="ReisingerIntelliApp_V4.Views.LocalDevicesScanPage"
-             Shell.NavBarIsVisible="False"
-             BackgroundColor="#1E1E1E">
+<ContentPage
+    x:Class="ReisingerIntelliApp_V4.Views.LocalDevicesScanPage"
+    xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:components="clr-namespace:ReisingerIntelliApp_V4.Components"
+    xmlns:converters="clr-namespace:ReisingerIntelliApp_V4.Converters"
+    xmlns:models="clr-namespace:ReisingerIntelliApp_V4.Models"
+    xmlns:viewmodels="clr-namespace:ReisingerIntelliApp_V4.ViewModels"
+    x:DataType="viewmodels:LocalDevicesScanPageViewModel"
+    BackgroundColor="#1E1E1E"
+    Shell.NavBarIsVisible="False">
 
-    <ContentPage.BindingContext>
-        <viewmodels:LocalDevicesScanPageViewModel />
-    </ContentPage.BindingContext>
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:InvertedBoolConverter x:Key="InvertedBoolConverter" />
+            <converters:SavedDeviceOpacityConverter x:Key="SavedDeviceOpacityConverter" />
+            <converters:IntToBoolConverter x:Key="IntToBoolConverter" />
+            <converters:StringToBoolConverter x:Key="StringToBoolConverter" />
+            <converters:PercentageToProgressConverter x:Key="PercentageToProgressConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
 
-    <Grid RowDefinitions="Auto,*,Auto,Auto">
-        <!-- Header with Back Button and Title -->
-        <Border Grid.Row="0" Padding="20,15" StrokeThickness="0">
+    <Grid RowDefinitions="Auto,*">
+        <!--  Header with Back Button and Title  -->
+        <Border
+            Grid.Row="0"
+            Padding="20,15"
+            StrokeThickness="0">
             <Border.Background>
                 <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
-                    <GradientStop Color="#2D2D2D" Offset="0.0" />
-                    <GradientStop Color="Transparent" Offset="1.0" />
+                    <GradientStop Offset="0.0" Color="#2D2D2D" />
+                    <GradientStop Offset="1.0" Color="Transparent" />
                 </LinearGradientBrush>
             </Border.Background>
-            
+
             <Grid ColumnDefinitions="Auto,*" RowDefinitions="*">
-                <!-- Back Button -->
-                <Button Grid.Column="0" 
-                        Grid.Row="0"
-                        Padding="0,0,0,0"
-                        Margin="0,0,0,7"
-                        x:Name="BackButton"
-                        Text="&#8249;"
-                        FontSize="30"
-                        TextColor="White"
-                        BackgroundColor="Transparent"
-                        BorderWidth="0"
-                        WidthRequest="40"
-                        HeightRequest="40"
-                        HorizontalOptions="Start"
-                        VerticalOptions="Center"
-                        Command="{Binding BackCommand}" />
-                <!-- Title -->
-                <Label Grid.Column="1" 
-                       Grid.Row="0"
-                       Text="{Binding Title}" 
-                       TextColor="White" 
-                       FontSize="20"
-                       FontFamily="SpaceMonoBold"
-                       HorizontalOptions="Start"
-                       VerticalOptions="Center"
-                       Margin="10,0,0,0" />
+                <!--  Back Button  -->
+                <Button
+                    x:Name="BackButton"
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Margin="0,0,0,7"
+                    Padding="0,0,0,0"
+                    BackgroundColor="Transparent"
+                    BorderWidth="0"
+                    Clicked="OnBackButtonClicked"
+                    FontSize="30"
+                    HeightRequest="40"
+                    HorizontalOptions="Start"
+                    Text="&#8249;"
+                    TextColor="White"
+                    VerticalOptions="Center"
+                    WidthRequest="40" />
+
+                <!--  Title  -->
+                <Label
+                    Grid.Row="0"
+                    Grid.Column="1"
+                    Margin="10,0,0,0"
+                    FontFamily="SpaceMonoBold"
+                    FontSize="20"
+                    HorizontalOptions="Start"
+                    Text="Local Device Scan"
+                    TextColor="White"
+                    VerticalOptions="Center" />
             </Grid>
         </Border>
 
-        <!-- Main Content -->
+        <!--  Main Content  -->
         <ScrollView Grid.Row="1" Padding="20">
             <StackLayout Spacing="20">
-                <!-- SSID Info -->
-                <StackLayout Spacing="5">
-                    <Label Text="SSID: MyNetwork" 
-                           FontSize="16" 
-                           FontFamily="SpaceMonoBold"
-                           TextColor="White" 
-                           HorizontalOptions="Start" />
-                </StackLayout>
-                
-                <!-- Device List -->
-                <StackLayout x:Name="LocalDevicesList" Spacing="15">
-                    <!-- Local devices will be added here dynamically -->
-                </StackLayout>
-                
-                <!-- Loading indicator -->
-                <ActivityIndicator IsVisible="{Binding IsBusy}" 
-                                  IsRunning="{Binding IsBusy}"
-                                  Color="#007AFF"
-                                  HorizontalOptions="Center" />
+
+                <!--  Scan Progress Section  -->
+                <Frame
+                    Padding="15"
+                    BackgroundColor="#3A3A3A"
+                    BorderColor="Transparent"
+                    CornerRadius="10"
+                    IsVisible="{Binding IsScanning}">
+                    <StackLayout Spacing="10">
+                        <Label
+                            FontSize="16"
+                            HorizontalOptions="Center"
+                            Text="{Binding ScanStatusMessage}"
+                            TextColor="White" />
+
+                        <ProgressBar Progress="{Binding ProgressPercentage, Converter={StaticResource PercentageToProgressConverter}}" ProgressColor="#007AFF" />
+
+                        <Label
+                            FontSize="14"
+                            HorizontalOptions="Center"
+                            TextColor="#B0B0B0">
+                            <Label.Text>
+                                <MultiBinding StringFormat="Fortschritt: {0} / {1} IPs ({2:F0}%)">
+                                    <Binding Path="ScannedCount" />
+                                    <Binding Path="TotalCount" />
+                                    <Binding Path="ProgressPercentage" />
+                                </MultiBinding>
+                            </Label.Text>
+                        </Label>
+                    </StackLayout>
+                </Frame>
+
+
+                <!--  Results Header  -->
+                <Label
+                    FontAttributes="Bold"
+                    FontSize="14"
+                    HorizontalOptions="Center"
+                    IsVisible="{Binding LocalDevices.Count, Converter={StaticResource IntToBoolConverter}}"
+                    TextColor="White">
+                    <Label.Text>
+                        <MultiBinding StringFormat="📱 Gefundene Intellidrive-Geräte: {0}">
+                            <Binding Path="LocalDevices.Count" />
+                        </MultiBinding>
+                    </Label.Text>
+                </Label>
+
+
+
+
+                <!--  Found Devices List  -->
+                <CollectionView IsVisible="{Binding LocalDevices.Count, Converter={StaticResource IntToBoolConverter}}" ItemsSource="{Binding LocalDevices}">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:LocalNetworkDeviceModel">
+                            <Border
+                                Margin="0,5"
+                                Padding="15"
+                                BackgroundColor="#2D2D2D"
+                                Opacity="{Binding IsAlreadySaved, Converter={StaticResource SavedDeviceOpacityConverter}}"
+                                Stroke="#404040"
+                                StrokeThickness="1">
+                                <Border.StrokeShape>
+                                    <RoundRectangle CornerRadius="8" />
+                                </Border.StrokeShape>
+                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                    <!--  Icon  -->
+                                    <Label
+                                        Grid.Column="0"
+                                        FontSize="16"
+                                        Text="🔗"
+                                        VerticalOptions="Center" />
+
+                                    <!--  Info  -->
+                                    <StackLayout
+                                        Grid.Column="1"
+                                        Margin="10,0,10,0"
+                                        Spacing="2">
+                                        <Grid ColumnDefinitions="*,Auto">
+                                            <Label
+                                                Grid.Column="0"
+                                                FontFamily="SpaceMonoBold"
+                                                FontSize="16"
+                                                Text="{Binding DisplayName}"
+                                                TextColor="White" />
+                                            <!--  Saved indicator  -->
+                                            <Label
+                                                Grid.Column="1"
+                                                FontSize="12"
+                                                IsVisible="{Binding IsAlreadySaved}"
+                                                Text="💾"
+                                                VerticalOptions="Center" />
+                                        </Grid>
+                                        <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto">
+                                            <Label
+                                                Grid.Column="0"
+                                                FontSize="12"
+                                                Text="{Binding IpAddress, StringFormat='IP: {0}'}"
+                                                TextColor="#B0B0B0" />
+                                            <Label
+                                                Grid.Column="1"
+                                                FontSize="12"
+                                                Text=" • "
+                                                TextColor="#B0B0B0" />
+                                            <Label
+                                                Grid.Column="2"
+                                                FontSize="12"
+                                                IsVisible="{Binding SerialNumber, Converter={StaticResource StringToBoolConverter}}"
+                                                Text="{Binding SerialNumber, StringFormat='SN: {0}'}"
+                                                TextColor="#B0B0B0" />
+                                            <Label
+                                                Grid.Column="3"
+                                                FontSize="12"
+                                                IsVisible="{Binding FirmwareVersion, Converter={StaticResource StringToBoolConverter}}"
+                                                Text=" • "
+                                                TextColor="#B0B0B0" />
+                                            <Label
+                                                Grid.Column="4"
+                                                FontSize="12"
+                                                IsVisible="{Binding FirmwareVersion, Converter={StaticResource StringToBoolConverter}}"
+                                                Text="{Binding FirmwareVersion, StringFormat='FW: {0}'}"
+                                                TextColor="#B0B0B0" />
+                                        </Grid>
+                                    </StackLayout>
+
+                                    <!--  Add (+) button  -->
+                                    <Button
+                                        Grid.Column="2"
+                                        Margin="2,0"
+                                        BackgroundColor="#4CAF50"
+                                        Command="{Binding Source={RelativeSource AncestorType={x:Type viewmodels:LocalDevicesScanPageViewModel}}, Path=AddDeviceCommand}"
+                                        CommandParameter="{Binding}"
+                                        CornerRadius="17"
+                                        FontSize="18"
+                                        HeightRequest="35"
+                                        IsVisible="{Binding IsAlreadySaved, Converter={StaticResource InvertedBoolConverter}}"
+                                        Text="+"
+                                        TextColor="White"
+                                        ToolTipProperties.Text="Add as device"
+                                        WidthRequest="35" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+
+                <!--  No Results Message  -->
+                <Frame
+                    Padding="20"
+                    BackgroundColor="#3A3A3A"
+                    BorderColor="Transparent"
+                    CornerRadius="10"
+                    IsVisible="{Binding LocalDevices.Count, Converter={StaticResource IntToBoolConverter}, ConverterParameter=true}">
+                    <Label
+                        FontSize="16"
+                        HorizontalOptions="Center"
+                        Text="📭 Noch keine Intellidrive-Geräte gefunden"
+                        TextColor="#B0B0B0" />
+                </Frame>
+
+                <!--  IP Range Input Section  -->
+                <Frame
+                    Padding="15"
+                    BackgroundColor="#2A2A2A"
+                    BorderColor="Transparent"
+                    CornerRadius="10">
+                    <StackLayout Spacing="15">
+                        <Label
+                            FontAttributes="Bold"
+                            FontSize="18"
+                            Text="🔍 IP-Bereich für Scan"
+                            TextColor="White" />
+
+                        <Grid ColumnDefinitions="*,Auto,*" ColumnSpacing="10">
+                            <Entry
+                                x:Name="StartIpEntry"
+                                Grid.Column="0"
+                                BackgroundColor="#3A3A3A"
+                                Keyboard="Numeric"
+                                Placeholder="Start IP (z.B. 192.168.1.1)"
+                                PlaceholderColor="#808080"
+                                Text="{Binding StartIp}"
+                                TextColor="White" />
+
+                            <Label
+                                Grid.Column="1"
+                                Text="bis"
+                                TextColor="White"
+                                VerticalOptions="Center" />
+
+                            <Entry
+                                x:Name="EndIpEntry"
+                                Grid.Column="2"
+                                BackgroundColor="#3A3A3A"
+                                Keyboard="Numeric"
+                                Placeholder="End IP (z.B. 192.168.1.254)"
+                                PlaceholderColor="#808080"
+                                Text="{Binding EndIp}"
+                                TextColor="White" />
+                        </Grid>
+
+                        <!--  Validation Message  -->
+                        <Label
+                            Margin="0,5,0,0"
+                            FontSize="12"
+                            IsVisible="{Binding HasValidationError}"
+                            Text="{Binding ValidationMessage}"
+                            TextColor="#FF3B30" />
+
+                        <!--  Scan Controls  -->
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                            <Button
+                                Grid.Column="0"
+                                BackgroundColor="#007AFF"
+                                Command="{Binding StartLocalScanCommand}"
+                                IsEnabled="{Binding IsScanning, Converter={StaticResource InvertedBoolConverter}}"
+                                Text="🚀 Scan Starten"
+                                TextColor="White" />
+
+                            <Button
+                                Grid.Column="1"
+                                BackgroundColor="#FF3B30"
+                                Command="{Binding StopScanCommand}"
+                                IsVisible="{Binding IsScanning}"
+                                Text="⏹️ Stop"
+                                TextColor="White" />
+                        </Grid>
+                    </StackLayout>
+                </Frame>
+
+
+
             </StackLayout>
         </ScrollView>
-
-        <!-- IP Range Input Section -->
-        <StackLayout Grid.Row="2" Padding="20,0,20,20" Spacing="15">
-            <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
-                <!-- Start IP Entry -->
-                <Entry Grid.Column="0"
-                       x:Name="StartIpEntry"
-                       Placeholder="Start IP"
-                       PlaceholderColor="#808080"
-                       TextColor="White"
-                       BackgroundColor="#2A2A2A"
-                       FontFamily="SpaceMonoBold"
-                       FontSize="14"
-                       HeightRequest="50"
-                       MaxLength="15"
-                       Text="192.168.0.1"
-                       TextChanged="OnIpEntryTextChanged" />
-                
-                <!-- End IP Entry -->
-                <Entry Grid.Column="1"
-                       x:Name="EndIpEntry"
-                       Placeholder="End IP"
-                       PlaceholderColor="#808080"
-                       TextColor="White"
-                       BackgroundColor="#2A2A2A"
-                       FontFamily="SpaceMonoBold"
-                       FontSize="14"
-                       HeightRequest="50"
-                       MaxLength="15"
-                       Text="192.168.0.254"
-                       TextChanged="OnIpEntryTextChanged" />
-            </Grid>
-            
-            <!-- Scan Button -->
-            <Button x:Name="ScanButton"
-                    Text="Scan Local Network"
-                    BackgroundColor="#007AFF"
-                    TextColor="White"
-                    FontFamily="SpaceMonoBold"
-                    FontSize="16"
-                    HeightRequest="50"
-                    CornerRadius="25"
-                    Command="{Binding ScanCommand}" />
-        </StackLayout>
-
-        <!-- Footer Component -->
-        <components:AppFooter Grid.Row="3" 
-                             x:Name="Footer" />
     </Grid>
-
 </ContentPage>

--- a/Views/LocalDevicesScanPage.xaml.cs
+++ b/Views/LocalDevicesScanPage.xaml.cs
@@ -6,25 +6,15 @@ public partial class LocalDevicesScanPage : ContentPage
 {
     private LocalDevicesScanPageViewModel? _viewModel;
 
-    public LocalDevicesScanPage()
+    public LocalDevicesScanPage(LocalDevicesScanPageViewModel viewModel)
     {
         InitializeComponent();
-        _viewModel = BindingContext as LocalDevicesScanPageViewModel;
-        SetupFooterEvents();
+        _viewModel = viewModel;
+        BindingContext = _viewModel;
     }
 
-    private void SetupFooterEvents()
+    private async void OnBackButtonClicked(object sender, EventArgs e)
     {
-        if (_viewModel != null)
-        {
-            Footer.LeftSectionTapped += (s, e) => _viewModel.HomeCommand.Execute(null);
-            Footer.CenterButtonTapped += (s, e) => _viewModel.RefreshCommand.Execute(null);
-            Footer.RightSectionTapped += (s, e) => _viewModel.SettingsCommand.Execute(null);
-        }
-    }
-
-    private void OnIpEntryTextChanged(object sender, TextChangedEventArgs e)
-    {
-        // Validate IP format - can be implemented later
+        await Shell.Current.GoToAsync("..");
     }
 }

--- a/Views/MainPage.xaml
+++ b/Views/MainPage.xaml
@@ -188,17 +188,17 @@
                                     <!--  Text  -->
                                     <StackLayout Grid.Row="1" Spacing="5">
                                         <Label
-                                            FontSize="14"
+                                            FontSize="10"
                                             LineBreakMode="WordWrap"
                                             Text="{Binding Text}"
                                             TextColor="White" />
-                                        
+
                                         <!--  Connection Status (only for WiFi devices with actions)  -->
-                                        <StackLayout 
-                                            Orientation="Horizontal" 
-                                            Spacing="8"
+                                        <StackLayout
+                                            HorizontalOptions="Center"
                                             IsVisible="{Binding HasActions}"
-                                            HorizontalOptions="Center">
+                                            Orientation="Horizontal"
+                                            Spacing="8">
                                             <!--  Status Indicator Dot  -->
                                             <Ellipse
                                                 Fill="{Binding ConnectionColor}"

--- a/Views/SaveLocalDevicePage.xaml
+++ b/Views/SaveLocalDevicePage.xaml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage x:Class="ReisingerIntelliApp_V4.Views.SaveLocalDevicePage"
+             xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:converters="clr-namespace:ReisingerIntelliApp_V4.Converters"
+             BackgroundColor="#1E1E1E"
+             Shell.NavBarIsVisible="False">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <converters:BoolToStatusConverter x:Key="BoolToStatusConverter" />
+            <converters:BoolToColorConverter x:Key="BoolToColorConverter" />
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <Grid RowDefinitions="Auto,*">
+        <Border Grid.Row="0" StrokeThickness="0">
+            <Border.Background>
+                <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                    <GradientStop Offset="0.0" Color="#2D2D2D" />
+                    <GradientStop Offset="1.0" Color="Transparent" />
+                </LinearGradientBrush>
+            </Border.Background>
+            <Grid ColumnDefinitions="Auto,*">
+                <Button x:Name="BackButton"
+                        Grid.Column="0"
+                        Command="{Binding BackCommand}"
+                        BackgroundColor="Transparent"
+                        BorderWidth="0"
+                        TextColor="White"
+                        FontSize="24"
+                        WidthRequest="60"
+                        HeightRequest="60"
+                        Text="&#8249;" />
+                <Label Grid.Column="1"
+                       Text="Save Local Device"
+                       FontFamily="SpaceMonoBold"
+                       FontSize="20"
+                       VerticalOptions="Center"
+                       TextColor="White" />
+            </Grid>
+        </Border>
+
+        <ScrollView Grid.Row="1" Padding="20">
+            <StackLayout Spacing="20">
+                <!-- Device Info -->
+                <Frame Padding="20" BackgroundColor="White" CornerRadius="12" HasShadow="True">
+                    <Grid ColumnDefinitions="120,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto" RowSpacing="10">
+                        <Label Grid.Row="0" Grid.Column="0" Text="Name:" FontAttributes="Bold" TextColor="#666"/>
+                        <Entry Grid.Row="0" Grid.Column="1" Text="{Binding DeviceName}" FontSize="16" BackgroundColor="#F8F8F8"/>
+                        <Label Grid.Row="1" Grid.Column="0" Text="IP:" FontAttributes="Bold" TextColor="#666"/>
+                        <Label Grid.Row="1" Grid.Column="1" Text="{Binding IpAddress}" FontSize="16"/>
+                        <Label Grid.Row="2" Grid.Column="0" Text="Firmware:" FontAttributes="Bold" TextColor="#666"/>
+                        <Label Grid.Row="2" Grid.Column="1" Text="{Binding FirmwareVersion}" FontSize="16"/>
+                        <Label Grid.Row="3" Grid.Column="0" Text="Serial:" FontAttributes="Bold" TextColor="#666"/>
+                        <Label Grid.Row="3" Grid.Column="1" Text="{Binding SerialNumber}" FontSize="16"/>
+                        <!-- Online status (match WiFi Save page design) -->
+                        <Label Grid.Row="4" Grid.Column="0" Text="Status:" FontAttributes="Bold" TextColor="#666"/>
+                        <Label Grid.Row="4" Grid.Column="1"
+                               FontSize="16"
+                               Text="{Binding IsOnline, Converter={StaticResource BoolToStatusConverter}}"
+                               TextColor="{Binding IsOnline, Converter={StaticResource BoolToColorConverter}}" />
+                    </Grid>
+                </Frame>
+
+                <!-- Credentials (optional for parity) -->
+                <Frame Padding="20" BackgroundColor="White" CornerRadius="12" HasShadow="True">
+                    <StackLayout Spacing="15">
+                        <Label FontAttributes="Bold" FontSize="18" Text="Gerätezugangsdaten" TextColor="#333" />
+
+                        <StackLayout Spacing="5">
+                            <Label FontAttributes="Bold" Text="Benutzername:" TextColor="#666" />
+                            <Entry BackgroundColor="#F8F8F8" Placeholder="Benutzername eingeben..." PlaceholderColor="#999" Text="{Binding Username}" />
+                        </StackLayout>
+
+                        <StackLayout Spacing="5">
+                            <Label FontAttributes="Bold" Text="Passwort:" TextColor="#666" />
+                            <Entry BackgroundColor="#F8F8F8" IsPassword="True" Placeholder="Passwort eingeben..." PlaceholderColor="#999" Text="{Binding Password}" />
+                        </StackLayout>
+                    </StackLayout>
+                </Frame>
+
+                <!-- Test connectivity -->
+                <Frame Padding="20" BackgroundColor="White" CornerRadius="12" HasShadow="True">
+                    <StackLayout Spacing="12">
+                        <Label Text="Verbindungstest" FontAttributes="Bold" FontSize="18" TextColor="#333"/>
+                        <Button Text="{Binding TestButtonText}" Command="{Binding TestConnectionCommand}" BackgroundColor="#007ACC" TextColor="White" CornerRadius="8" HeightRequest="45" IsEnabled="{Binding CanTestConnection}"/>
+                        <Label Text="{Binding StatusMessage}" TextColor="{Binding StatusColor}" IsVisible="{Binding ShowStatusMessage}" HorizontalOptions="Center" FontAttributes="Bold"/>
+                    </StackLayout>
+                </Frame>
+
+                <!-- Actions -->
+                <Grid ColumnDefinitions="*,*" ColumnSpacing="15" Margin="0,10,0,30">
+                    <Button Grid.Column="0" Text="Abbrechen" Command="{Binding CancelCommand}" BackgroundColor="#6C757D" TextColor="White" CornerRadius="8" HeightRequest="50"/>
+                    <Button Grid.Column="1" Text="Gerät speichern" Command="{Binding SaveDeviceCommand}" IsEnabled="{Binding CanSaveDevice}" BackgroundColor="#28A745" TextColor="White" CornerRadius="8" HeightRequest="50"/>
+                </Grid>
+            </StackLayout>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/Views/SaveLocalDevicePage.xaml.cs
+++ b/Views/SaveLocalDevicePage.xaml.cs
@@ -1,0 +1,27 @@
+using ReisingerIntelliApp_V4.ViewModels;
+
+namespace ReisingerIntelliApp_V4.Views;
+
+public partial class SaveLocalDevicePage : ContentPage
+{
+    private readonly SaveLocalDevicePageViewModel _vm;
+
+    public SaveLocalDevicePage(SaveLocalDevicePageViewModel vm)
+    {
+        InitializeComponent();
+        _vm = vm;
+        BindingContext = _vm;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        _vm.StartOnlineStatusMonitoring();
+    }
+
+    protected override void OnDisappearing()
+    {
+        base.OnDisappearing();
+        _vm.StopOnlineStatusMonitoring();
+    }
+}


### PR DESCRIPTION
…on; local status groundwork; UI parity and polling prep

- WifiScan refresh: keep old list if scan returns no results; better status text
- SaveLocalDevice: page+VM, per-request auth test against /intellidrive/beep; shows and saves serial; editable name
- LAN scan: extract serial from /intellidrive/version Content.DEVICE_SERIALNO; fallback to /intellidrive/device_id
- IntellidriveApi: typed models and endpoints; per-request auth
- Converters cleanup (canonical BoolToColor)
- MainPage: hooks for local status updates (polling to follow)